### PR TITLE
feat: テストをシステムテストとレベルテストに分離 (Issue #20)

### DIFF
--- a/test.html
+++ b/test.html
@@ -6,53 +6,157 @@
     <title>ゲームテスト</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
-            max-width: 800px;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            max-width: 1000px;
             margin: 0 auto;
             padding: 20px;
-            background-color: #f5f5f5;
+            background-color: #f0f2f5;
+            color: #1a1a1a;
         }
         
         h1 {
-            color: #333;
+            color: #2c3e50;
             text-align: center;
+            margin-bottom: 30px;
+            font-size: 2.5em;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.1);
+        }
+        
+        h2 {
+            color: #34495e;
+            margin-bottom: 20px;
+            font-size: 1.8em;
+        }
+        
+        h3 {
+            margin: 15px 0;
+            font-size: 1.3em;
         }
         
         .test-results {
             background-color: white;
+            padding: 30px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        
+        .overall-summary {
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 30px;
+            text-align: center;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        
+        .overall-summary.test-pass {
+            background: linear-gradient(135deg, #d4edda 0%, #c3e6cb 100%);
+            border: 2px solid #28a745;
+        }
+        
+        .overall-summary.test-fail {
+            background: linear-gradient(135deg, #f8d7da 0%, #f5c6cb 100%);
+            border: 2px solid #dc3545;
+        }
+        
+        .overall-summary h3 {
+            margin: 0 0 10px 0;
+            font-size: 1.6em;
+        }
+        
+        .overall-summary p {
+            margin: 0;
+            font-size: 1.1em;
+            color: #333;
+        }
+        
+        .test-category {
+            margin-bottom: 25px;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+        }
+        
+        .test-category h3 {
+            margin: 0;
+            padding: 15px 20px;
+            background-color: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            font-size: 1.4em;
+        }
+        
+        .test-category.category-pass h3 {
+            background-color: #e7f5e7;
+            color: #155724;
+        }
+        
+        .test-category.category-fail h3 {
+            background-color: #fde7e9;
+            color: #721c24;
+        }
+        
+        .category-summary {
+            padding: 12px 20px;
+            background-color: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            font-size: 0.95em;
+            color: #6c757d;
+        }
+        
+        .test-details {
+            background-color: #fff;
+            padding: 10px 20px 15px;
         }
         
         .test-item {
-            margin: 10px 0;
-            padding: 10px;
-            border-radius: 4px;
+            margin: 8px 0;
+            padding: 10px 15px;
+            border-radius: 6px;
+            font-size: 0.95em;
+            transition: all 0.2s ease;
+        }
+        
+        .test-item:hover {
+            transform: translateX(5px);
         }
         
         .test-pass {
-            background-color: #d4edda;
+            background-color: #e7f5e7;
             color: #155724;
-            border: 1px solid #c3e6cb;
+            border-left: 4px solid #28a745;
         }
         
         .test-fail {
-            background-color: #f8d7da;
+            background-color: #fde7e9;
             color: #721c24;
-            border: 1px solid #f5c6cb;
-        }
-        
-        .test-summary {
-            font-weight: bold;
-            margin-top: 20px;
-            padding: 15px;
-            background-color: #e9ecef;
-            border-radius: 4px;
+            border-left: 4px solid #dc3545;
         }
         
         #gameCanvas {
             display: none;
+        }
+        
+        /* アニメーション */
+        @keyframes slideIn {
+            from {
+                opacity: 0;
+                transform: translateY(20px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+        
+        .test-category {
+            animation: slideIn 0.5s ease forwards;
+        }
+        
+        .test-category:nth-child(2) {
+            animation-delay: 0.1s;
+        }
+        
+        .test-category:nth-child(3) {
+            animation-delay: 0.2s;
         }
     </style>
 </head>


### PR DESCRIPTION
## 概要
Issue #20 対応：テストをシステムテストとレベルテストに分離し、段階的実行と視覚的に分かりやすい結果表示を実装しました。

## 変更内容

### 1. テストフレームワークの拡張
- `TestRunner`クラスにカテゴリサポートを追加
- 実行時間の計測機能を追加
- テスト結果のサマリー情報を返すように改善

### 2. テスト結果表示の改善
- `TestResultDisplay`クラスを新規作成
- 全体サマリーとカテゴリ別結果を表示
- 成功/失敗が一目で分かるビジュアルデザイン

### 3. テストの分離と段階実行
- **システムテスト**: 基本的な機能とクラスの動作確認
  - 設定ファイルの読み込み
  - プレイヤー、入力マネージャー、ゲーム状態のテスト
  - 基本的な動作テスト
- **レベルテスト**: レベルデータ固有のテスト
  - プラットフォーム配置
  - セクション構造
  - ゲームバランス要素

### 4. 実行フロー
```
1. システムテストを実行
2. システムテストが全て成功した場合のみレベルテストを実行
3. 結果を視覚的に分かりやすく表示
```

## スクリーンショット
- 全体サマリーで成功/失敗が一目で分かる
- カテゴリごとに結果をグループ化
- 実行時間を表示
- アニメーションで段階的に表示

## テスト結果
- ✅ **npm test**: 9/9 成功
- ✅ **ブラウザテスト環境**: 正常動作確認

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)